### PR TITLE
Add authors to version_control.txt

### DIFF
--- a/source/version_control.txt
+++ b/source/version_control.txt
@@ -2,6 +2,8 @@
 Version Control with git
 *************************
 
+*Authors: Joseph Long, Lauren Chambers*
+
 Version control systems keep track of changes to code, documents, and other files as you work. While this document will discuss one particular version control system, ``git`` [#gitproject]_ , the *concept* of version control shows up everywhere from iCloud to Wikipedia to NASA project management. That's because the simple idea of tracking changes is very powerful, giving authors and programmers great flexibility in their work.
 
 .. image:: figures/version_control/versioncontrol_meme.png


### PR DESCRIPTION
After seeing it an author list on `computer_setup.txt`, I looked through the commit history of `version_control.txt` and added a list of authors to the page. From the commits I saw, it seemed like Joseph and I wrote basically all of the content on the page (though of course, if anyone disagrees and wants to add to the list, please feel free).