### PR TITLE
Updated the Spectroscopy_training jupyter notebook

### DIFF
--- a/source/downloads/notebooks/Spectroscopy_Training.ipynb
+++ b/source/downloads/notebooks/Spectroscopy_Training.ipynb
@@ -11,7 +11,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 1. Retrieving Data from MAST\n",
+    "<b> A very brief introduction to HST spectral data </b>\n",
+    "\n",
+    "For HST spectral data, there are four types of files:\n",
+    "* raw \n",
+    "    * COS: `rawtag`, `rawaccum`, `rawacq`\n",
+    "    * STIS: `raw`, `tag`, `wav`\n",
+    "* support\n",
+    "    * `asn`, `spt`, `trl`, and more\n",
+    "* intermediate\n",
+    "    * `corrtag`, `crj`, `flt`, and more\n",
+    "* products\n",
+    "    * `x1d`, `x1dsum`\n",
+    "\n",
+    "Raw data has undergone no processing besides generic conversion from spacecraft data to FITS. Support files contain information about spacecraft telemetry (spt), exposures that should be associated (asn), pipeline processing (trl), etc. Intermediate products are files produced by each instrument’s calibration pipeline on the way to extracting a spectrum.  Products are fully calibrated, extracted 1-D spectra and typically have `x1d` in the extension. See the Instrument Data Handbooks for a full list of all data file types.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Retrieving the Required Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "***First, make a directory in your central store to put your data in.***"
    ]
   },
@@ -36,11 +63,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
-    "`mkdir mast_data`"
+    "There are 2 options for obtaining the data necessary for this tutorial. For individuals working through this assignment, we recommend using Option 2 to gain some experience working with MAST (the Mikulski Archive for Space Telescopes). If you are working through this in a group during a 1 hr training session, Option 1 of copying the files from a training directory on central store is recommended so that more time is focused on the spectroscopy than on resolving any difficulties with MAST."
    ]
   },
   {
@@ -49,44 +74,30 @@
     "collapsed": true
    },
    "source": [
-    "`cp /user/jotaylor/new_hire_training/*fits .`"
+    "<b> Option 1: Copy from directory on central store </b>\n",
+    "\n",
+    "Note that when using this option it is possible that the file headers have become out of date with respect to what the calibration pipelines are expecting (particularly calcos, since it is under active development). This can cause problems with the portions of this tutorial where you run the data through the pipelines.\n",
+    "\n",
+    "`cp /grp/hst/riab/training/spectroscopy/*.fits .`\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For HST spectral data, there are three types of files:\n",
-    "* raw \n",
-    "    * COS: `rawtag`, `rawaccum`, `rawacq`\n",
-    "    * STIS: `raw`, `tag`, `wav`\n",
-    "* support\n",
-    "    * `asn`, `spt`, `trl`, and more\n",
-    "* intermediate\n",
-    "    * `corrtag`, `crj`, `flt`, and more\n",
-    "* products\n",
-    "    * `x1d`, `x1dsum`\n",
-    "\n",
-    "Raw data has undergone no processing besides generic conversion from spacecraft data to FITS. Intermediate products are files produced by each instrument’s calibration pipeline on the way to extracting a spectrum.  Products are fully calibrated, extracted 1-D spectra and typically have `x1d` in the extension. See the Instrument Data Handbooks for a full list of all data file types.\n",
+    "<b> Option 2: Download data from MAST </b>\n",
     "\n",
     "To retrieve STIS data by its filename, simply enter the name in \"Dataset\" field in a [MAST search](http://archive.stsci.edu/hst/search.php). For COS data, however, you must search by the individual dataset's association name (more info [here](http://www.stsci.edu/hst/cos/documents/handbooks/datahandbook/ch2_cos_data5.html#460268)).\n",
     "\n",
-    "***Retrieve two datasets, lbgu17qnq (association lbgu17010) and o8k401010 from the archive.*** Be sure to retrieve both un-calibrated and calibrated products.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "`ls`"
+    "***Retrieve two datasets, lbgu17qnq (association lbgu17010) and o8k401010 from the archive.*** Be sure to retrieve both un-calibrated and calibrated products. Note that each instrument on HST (past and present) is assigned a letter of the alphabet, and all data files produced by that instrument begin with this letter. These are l for COS and o for STIS.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "At this point, we will assume that the data are located in the same directory where you are running this notebook. If not, cd into the directory where the data are located. Note that this is important for later, as trying to run the calstis pipeline from elsewhere can cause problems where it cannot find the necessary reference files.\n",
+    "\n",
     "First, let's look at the primary headers and identify some important parameters."
    ]
   },
@@ -94,7 +105,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -122,7 +133,7 @@
    },
    "outputs": [],
    "source": [
-    "# your code here"
+    "# your code here\n"
    ]
   },
   {
@@ -135,9 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run this cell.\n",
@@ -155,9 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for hdr in [cos_hdr0, stis_hdr0]:\n",
@@ -180,9 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run this cell.\n",
@@ -200,9 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run this cell.\n",
@@ -234,16 +237,16 @@
    "source": [
     "# Run this cell.\n",
     "import os\n",
-    "os.environ[\"oref\"] = \"/grp/hst/cdbs/oref/\"\n",
-    "os.environ[\"lref\"] = \"/grp/hst/cdbs/lref/\""
+    "#Note the environment variable names begin with their respective instrument letters\n",
+    "#i.e., o and l for STIS and COS, respectively\n",
+    "os.environ[\"oref\"] = '/grp/crds/hst/references/hst/'\n",
+    "os.environ[\"lref\"] = '/grp/crds/hst/references/hst/'"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run this cell.\n",
@@ -289,9 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run this cell.\n",
@@ -321,8 +322,15 @@
    "outputs": [],
    "source": [
     "# Run this cell.\n",
-    "# calcos.calcos(cos_asn, outdir=\"cos_backcorr_omit\")\n",
-    "cp /user/jotaylor/new_hire_training/cos_backcorr_omit/* /user/myname/spect_training/cos_backcorr_omit"
+    "cos_asn='lbgu17010_asn.fits'\n",
+    "calcos.calcos(cos_asn, outdir=\"cos_backcorr_omit\")\n",
+    "\n",
+    "#If you copied the data files from the central store directory instead of downloading them from MAST, it is possible\n",
+    "#that the header keywords are out-of-date with respect to what the current version of calcos expects. You can either\n",
+    "#go back and download the datasets from MAST, or use the following command to copy a previously processed data set\n",
+    "#from central store\n",
+    "\n",
+    "#cp /grp/hst/riab/training/spectroscopy/cos_backcorr_omit/* /user/myname/spect_training/cos_backcorr_omit"
    ]
   },
   {
@@ -335,12 +343,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# your code here to change BACKCORR"
+    "# your code here to change BACKCORR\n"
    ]
   },
   {
@@ -355,13 +361,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Calibrate the STIS raw file, and be sure to specify a trailing slash for the output directory.\n",
-    "calstis.calstis(stis_raw, outroot=\"stis_backcorr_omit/\")"
+    "\n",
+    "#Make sure that you are running this from the same directory where the STIS data files are located\n",
+    "#Otherwise, calstis may not be able to find the necessary reference files. An output of \"0\" means that calstis\n",
+    "#succeeded, while an output of \"1\" means that it failed. The argument verbose=True can be added to print more details.\n",
+    "\n",
+    "calstis.calstis(stis_raw, outroot=\"stis_backcorr_omit/\")\n",
+    "\n",
+    "#cp /grp/hst/riab/training/spectroscopy/stis_backcorr_omit/* /user/myname/spect_training/stis_backcorr_omit"
    ]
   },
   {
@@ -394,7 +405,7 @@
    },
    "outputs": [],
    "source": [
-    "# your code here"
+    "# your code here\n"
    ]
   },
   {
@@ -407,15 +418,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run this cell.\n",
     "print(cos_x1d_orig[\"wavelength\"].shape)\n",
     "print(cos_x1d_orig[\"segment\"])\n",
     "print(stis_x1d_orig[\"wavelength\"].shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see that the COS x1d file contains two spectra, one each for the A and B segments of the FUV detector, while the STIS x1d file contains a single spectrum. Both files store the wavelength and flux as 2D arrays. The following cell will combine the 2 COS spectra, and collapse the various arrays to 1D."
    ]
   },
   {
@@ -449,7 +465,7 @@
    },
    "outputs": [],
    "source": [
-    "# your code here"
+    "# your code here\n"
    ]
   },
   {
@@ -478,9 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Run this cell.\n",
@@ -506,12 +520,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# your code here"
+    "# your code here\n"
    ]
   },
   {
@@ -525,13 +537,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Use plt.plot instead of plt.subplots\n",
-    "plt.plot(wl, flux, color=...)"
+    "# e.g. plt.plot(wl, flux, color=...)\n",
+    "\n",
+    "#your code here\n"
    ]
   },
   {
@@ -561,7 +573,7 @@
    },
    "outputs": [],
    "source": [
-    "# your code here"
+    "# your code here\n"
    ]
   },
   {
@@ -577,7 +589,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# your code here"
+    "# your code here\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# your code here\n"
    ]
   },
   {
@@ -608,15 +629,17 @@
    },
    "outputs": [],
    "source": [
-    "# your code here"
+    "# your code here\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Computing SNR\n",
-    "The signal-to-noise ratio, SNR, is an important statistic of spectra. Signal can be approximated with a low-order polynomial fit to a continuum region where there are no absorption or emission features. Noise can be approximated as the standard deviation of the fit subtracted from the data. ***Smooth the COS data using boxcar=6, and STIS data using boxcar=2. Then, follow the example below to determine the average SNR for the COS and STIS data.***"
+    "## Computing the signal to noise ratio (S/N)\n",
+    "The signal-to-noise ratio, S/N or SNR (although SNR is also used for supernova remnant in astronomy), is an important statistic of spectra. Signal can be approximated with a low-order polynomial fit to a continuum region where there are no absorption or emission features. Noise can be approximated as the standard deviation of the fit subtracted from the data. ***Smooth the COS data using boxcar=6, and STIS data using boxcar=2. Then, follow the example below to determine the average SNR for the COS and STIS data.***\n",
+    "\n",
+    "Hint: Make sure to perform your fit and S/N calculation over a line-free region."
    ]
   },
   {
@@ -643,8 +666,17 @@
    },
    "outputs": [],
    "source": [
-    "# your code here"
+    "# your code here\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -663,7 +695,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added more descriptive text.
Updated location of data files on central store. 
Updated lref and oref variables. 
Added instructions to avoid common calstis failure mode.